### PR TITLE
fix parens error

### DIFF
--- a/src/ADebouncer.cpp
+++ b/src/ADebouncer.cpp
@@ -40,7 +40,7 @@ boolean ADebouncer::debounce(boolean input) {
     }
   }
   _rising = _output & !_prevOutput;
-  _falling = !_output & _prevOutput;
+  _falling = (!_output) & _prevOutput;
   return _output;
 }
 


### PR DESCRIPTION
On the recent version of the Arduino IDE I get the following error:
```
/Users/nick/Documents/Arduino/libraries/ADebouncer/src/ADebouncer.cpp: In member function 'boolean ADebouncer::debounce(boolean)':
/Users/nick/Documents/Arduino/libraries/ADebouncer/src/ADebouncer.cpp:43:14: error: suggest parentheses around operand of '!' or change '&' to '&&' or '!' to '~' [-Werror=parentheses]
   _falling = !_output & _prevOutput;
              ^~~~~~~~
cc1plus: some warnings being treated as errors

exit status 1

Compilation error: exit status 1
```